### PR TITLE
Allow Fog owl door to use initialState as a prop

### DIFF
--- a/objects/fog-owl-door/config.js
+++ b/objects/fog-owl-door/config.js
@@ -17,7 +17,7 @@ function onTriggerAreaWasEntered(self, event, world) {
   }
 
   if (isOpenCloseKey(self, event)) {
-    self.state.fsm.action("open");
+    self.state.fsm?.action("open");
     return;
   }
 }

--- a/scripts/FSM.js
+++ b/scripts/FSM.js
@@ -40,6 +40,8 @@ module.exports = class FSM {
   constructor(states, initialState) {
     this.currentState = initialState;
     this.states = states;
+
+    this.states[initialState].onEnter?.();
   }
 
   /**
@@ -49,9 +51,7 @@ module.exports = class FSM {
    * @param {String} action - the string value of a valid action
    */
   action(action, payload) {
-    if (this.states[this.currentState].actions[action]) {
-      this.states[this.currentState].actions[action](payload);
-    }
+    this.states[this.currentState].actions[action]?.(payload);
   }
 
   /**
@@ -63,8 +63,6 @@ module.exports = class FSM {
   transition(state) {
     this.currentState = state;
 
-    if (this.states[this.currentState].onEnter) {
-      this.states[this.currentState].onEnter();
-    }
+    this.states[this.currentState].onEnter?.();
   }
 };

--- a/scripts/initOpenCloseFsm.js
+++ b/scripts/initOpenCloseFsm.js
@@ -66,7 +66,7 @@ const initOpenCloseFsm =
           },
         },
       },
-      "closed"
+      self.initialState ?? "closed"
     );
 
     self.setState({ fsm });


### PR DESCRIPTION
I think it looks better aesthetically and logically if you start on the fog owl's landing ramp facing out with the door open.

This is not possible in the current door since it always starts closed.

This PR lets you set initial door state. If you set it to `"open"` via a tiled prop `initialState`  the door will start in the open state. This is useful if the player is already inside of the door open area when they spawn.