### PR TITLE
Made Workflow for Prepping Releases

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,6 +9,12 @@ on:
         - patch
         default: patch
         required: true
+  workflow_call:
+    inputs:
+      release_type:
+        type: string
+        default: patch
+        required: true
 
 jobs:
   setup:


### PR DESCRIPTION
- Checks out repo
- Setups up node and npm
- Increments the package/package-lock file versions by 1 based on the selected release type (major, minor, patch, etc)
- Stores the new version in an environment variable
- Configures git for the action, checks out the the release branch, and pushes a new commit to remote before creating a PR into main