### PR TITLE
Update validator.js to show nesting

### DIFF
--- a/levels/challenge-questions/objectives/flatten-array/validator.js
+++ b/levels/challenge-questions/objectives/flatten-array/validator.js
@@ -6,7 +6,7 @@ const assertTestCase = (testFunction) => (input, expected) => {
   assert.deepStrictEqual(
     testResult,
     expected,
-    `Expected "${expected}" from input "[${input}]", but received "${testResult}".`
+    `Expected "${JSON.stringify(expected)}" from input "[${JSON.stringify(expected)}]", but received "${JSON.stringify(expected)}".`
   );
 };
 

--- a/levels/challenge-questions/objectives/flatten-array/validator.js
+++ b/levels/challenge-questions/objectives/flatten-array/validator.js
@@ -6,7 +6,7 @@ const assertTestCase = (testFunction) => (input, expected) => {
   assert.deepStrictEqual(
     testResult,
     expected,
-    `Expected "${JSON.stringify(expected)}" from input "[${JSON.stringify(expected)}]", but received "${JSON.stringify(expected)}".`
+    `Expected "${JSON.stringify(expected)}" from input "${JSON.stringify(expected)}", but received "${JSON.stringify(expected)}".`
   );
 };
 


### PR DESCRIPTION
When testing the user's code to see if their function appropriately flattens an array for one of the new Ducktypium challenges, the code in validator.js currently prints out the appropriate value regardless of nesting for the returned value as shown in the image below:
![flatten](https://user-images.githubusercontent.com/45082599/181765722-9a9d329b-778d-468e-b157-f07c8360173e.PNG)
Specifically, the code shown in the image just returns the array without any modification. On the right, however, both the expected result and the result from running the code appear to be the same, and none of the values printed reflect the fact that the item "legacy wuz here" was in a nested array.
Using JSON.stringify() within the template literal would make this nesting visible.
