### PR TITLE
Fixed Typo Neumann object

### DIFF
--- a/objects/head-of-house-neumann/config.js
+++ b/objects/head-of-house-neumann/config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   spriteSheets: {
     twilioQuestApiHeadHouseNeumann: {
-      fileName: "NPC_HeadHouses_Neumann.png",
+      fileName: "NPC_HeadHouse_Neumann.png",
       frameDimensions: {
         width: 32,
         height: 32,


### PR DESCRIPTION
Fixed typo in head of house neumann object config file that was causing him to not appear in map